### PR TITLE
Moved aws-sdk to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "url": "git+https://github.com/actionably/dashbot-logger.git"
   },
   "dependencies": {
-    "aws-sdk": "^2.401.0",
     "generic-pool": "^3.6.1",
     "lodash": "^4.17.11",
     "pump": "^3.0.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "aws-sdk": "^2.401.0",
     "eslint": "^5.13.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",


### PR DESCRIPTION
The module serverless-webpack would include the aws-sdk in the production package, because its a dependency in your module.
This requires an extra deletion of the aws-sdk module in node_modules. To avoid this, just move it to devDependencies.