### PR TITLE
Fixes the isLambda import

### DIFF
--- a/lib/log-stream.js
+++ b/lib/log-stream.js
@@ -2,7 +2,7 @@
 const LogTransformer = require('./log-transformer')
 const LogWriter = require('./log-writer')
 const pump = require('pump')
-const { isLambda } = require('util')
+const { isLambda } = require('./util')
 
 class LoggerWrapper {
   constructor (logger) {


### PR DESCRIPTION
Seems like because of a typo the global `util` package was being required instead of the package at `lib/util.js`